### PR TITLE
Fix map decode

### DIFF
--- a/v2/erlang/erlang.go
+++ b/v2/erlang/erlang.go
@@ -627,7 +627,7 @@ func binaryToTerms(i int, reader *bytes.Reader) (int, interface{}, error) {
 			return i, nil, err
 		}
 		i += 4
-		var pairs map[interface{}]interface{}
+		pairs := make(map[interface{}]interface{})
 		for lengthIndex := 0; lengthIndex < int(length); lengthIndex++ {
 			var key interface{}
 			i, key, err = binaryToTerms(i, reader)

--- a/v2/erlang/erlang_test.go
+++ b/v2/erlang/erlang_test.go
@@ -284,6 +284,17 @@ func TestDecodeBinaryToTermLargeBigInteger(t *testing.T) {
 	bignum2, _ := big.NewInt(0).SetString("-6618611909121", 10)
 	assertEqual(t, bignum2, decode(t, "\x83o\x00\x00\x00\x06\x01\x01\x02\x03\x04\x05\x06"), "")
 }
+func TestDecodeBinaryToTermMap(t *testing.T) {
+	assertDecodeError(t, "EOF", "\x83t", "")
+	assertDecodeError(t, "unexpected EOF", "\x83t\x00", "")
+	assertDecodeError(t, "unexpected EOF", "\x83t\x00\x00", "")
+	assertDecodeError(t, "unexpected EOF", "\x83t\x00\x00\x00", "")
+	assertDecodeError(t, "EOF", "\x83t\x00\x00\x00\x01", "")
+	assertEqual(t, make(OtpErlangMap), decode(t, "\x83t\x00\x00\x00\x00"), "")
+	map1 := make(OtpErlangMap)
+	map1[OtpErlangAtom("a")] = uint8(1)
+	assertEqual(t, map1, decode(t, "\x83t\x00\x00\x00\x01d\x00\x01aa\x01"), "")
+}
 func TestDecodeBinaryToTermCompressedTerm(t *testing.T) {
 	assertDecodeError(t, "EOF", "\x83P", "")
 	assertDecodeError(t, "unexpected EOF", "\x83P\x00", "")


### PR DESCRIPTION
Decoding non-empty Erlang maps panicked due to a lack of initialization. With this change, whether the Erlang map is empty or not, an initialized map will be returned as the decoded value.