### PR TITLE
Read compressed data completely

### DIFF
--- a/v2/erlang/erlang.go
+++ b/v2/erlang/erlang.go
@@ -782,7 +782,7 @@ func binaryToTerms(i int, reader *bytes.Reader) (int, interface{}, error) {
 		}
 		dataUncompressed := make([]byte, sizeUncompressed)
 		var sizeUncompressedStored int
-		sizeUncompressedStored, _ = compress.Read(dataUncompressed)
+		sizeUncompressedStored, _ = io.ReadFull(compress, dataUncompressed)
 		err = compress.Close()
 		if err != nil {
 			return i, nil, err


### PR DESCRIPTION
Fixes reading lists with large tuples.

See https://github.com/gesellix/couchdb-prometheus-exporter/pull/239 for a real life example with an encoded `update_seq` from Apache CouchDB.
